### PR TITLE
Show json invalid hint if json is invalid, not only if it's invalid according to schema

### DIFF
--- a/react-with-json-logic/src/App.tsx
+++ b/react-with-json-logic/src/App.tsx
@@ -20,11 +20,9 @@ import { QuestionnaireExecution } from "./components/QuestionnaireExecution";
 import { QuestionnaireEditor } from "./components/questionnaireEditor/QuestionnaireEditor";
 import { Questionnaire } from "./models/Questionnaire";
 import { useAppDispatch } from "./store/store";
-import { useSelector } from "react-redux";
-import { questionnaireJsonSelector, setQuestionnaireInEditor } from "./store/questionnaireInEditor";
-import jsonschema from "jsonschema";
-import questionnaireSchema from "./schemas/questionnaire.json";
+import { setQuestionnaireInEditor, questionnaireInEditorSelector } from "./store/questionnaireInEditor";
 import { QuestionnaireSelectionDrawer } from "./components/QuestionnaireSelection";
+import { useSelector } from "react-redux";
 
 type QuestionnairesList = Array<{ name: string; path: string }>;
 
@@ -59,7 +57,6 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export const App: React.FC = () => {
   const dispatch = useAppDispatch();
-  const questionnaireJson = useSelector(questionnaireJsonSelector);
 
   const currentQuestionnaire = useSelector(questionnaireInEditorSelector);
 
@@ -69,9 +66,6 @@ export const App: React.FC = () => {
     undefined
   );
   const [executedQuestionnaire, setExecutedQuestionnaire] = useState<Questionnaire | undefined>(undefined);
-
-  const [showJsonInvalidMessage, setShowJsonInvalidMessage] = useState(false);
-  const [schemaValidationErrors, setSchemaValidationErrors] = useState<jsonschema.ValidationError[]>([]);
 
   const [showMenu, setShowMenu] = useState(false);
 
@@ -108,23 +102,6 @@ export const App: React.FC = () => {
       });
     }
   }, [dispatch, currentQuestionnairePath]);
-
-  useEffect(() => {
-    try {
-      const validator = new jsonschema.Validator();
-      const validationResult = validator.validate(questionnaireJson, questionnaireSchema);
-      if (validationResult.errors.length > 0) {
-        setSchemaValidationErrors(validationResult.errors);
-        setShowJsonInvalidMessage(true);
-        return;
-      }
-      setShowJsonInvalidMessage(false);
-      setSchemaValidationErrors([]);
-      overwriteCurrentQuestionnaire(questionnaireJson);
-    } catch (e) {
-      setShowJsonInvalidMessage(true);
-    }
-  }, [questionnaireJson]);
 
   return (
     <ThemeProvider theme={theme}>

--- a/react-with-json-logic/src/App.tsx
+++ b/react-with-json-logic/src/App.tsx
@@ -165,7 +165,6 @@ export const App: React.FC = () => {
                     overwriteCurrentQuestionnaire(originalCurrentQuestionnaire);
                   }
                 }}
-                schemaValidationErrors={schemaValidationErrors}
                 isJsonMode={isJsonMode}
               />
             </Grid>

--- a/react-with-json-logic/src/App.tsx
+++ b/react-with-json-logic/src/App.tsx
@@ -61,6 +61,8 @@ export const App: React.FC = () => {
   const dispatch = useAppDispatch();
   const questionnaireJson = useSelector(questionnaireJsonSelector);
 
+  const currentQuestionnaire = useSelector(questionnaireInEditorSelector);
+
   const [allQuestionnaires, setAllQuestionnaires] = useState<QuestionnairesList>([]);
   const [currentQuestionnairePath, setCurrentQuestionnairePath] = useState<string>("");
   const [originalCurrentQuestionnaire, setOriginalCurrentQuestionnaire] = useState<Questionnaire | undefined>(
@@ -171,8 +173,8 @@ export const App: React.FC = () => {
             <Grid item xs={showMenu ? 3 : 4} data-testid="QuestionnaireExecution" onClick={() => setShowMenu(false)}>
               {executedQuestionnaire !== undefined ? (
                 <QuestionnaireExecution
-                  isJsonInvalid={showJsonInvalidMessage}
-                  currentQuestionnaire={executedQuestionnaire}
+                  currentQuestionnaire={currentQuestionnaire.questionnaire}
+                  isJsonInvalid={currentQuestionnaire.hasErrors}
                 />
               ) : null}
             </Grid>

--- a/react-with-json-logic/src/components/QuestionnaireExecution.tsx
+++ b/react-with-json-logic/src/components/QuestionnaireExecution.tsx
@@ -9,8 +9,8 @@ import { Primitive } from "../Primitive";
 import "typeface-fira-sans";
 
 type QuestionnaireExecutionProps = {
-  isJsonInvalid?: boolean;
   currentQuestionnaire: Questionnaire;
+  isJsonInvalid: boolean;
 };
 
 const useStyles = makeStyles(() =>
@@ -53,8 +53,8 @@ const useStyles = makeStyles(() =>
 );
 
 export const QuestionnaireExecution: React.FC<QuestionnaireExecutionProps> = ({
-  isJsonInvalid,
   currentQuestionnaire,
+  isJsonInvalid,
 }) => {
   const [questionnaireEngine, setQuestionnaireEngine] = useState(new QuestionnaireEngine(currentQuestionnaire));
   const [currentQuestion, setCurrentQuestion] = useState<Question | undefined>(undefined);

--- a/react-with-json-logic/src/components/questionnaireEditor/QuestionnaireEditor.tsx
+++ b/react-with-json-logic/src/components/questionnaireEditor/QuestionnaireEditor.tsx
@@ -1,6 +1,5 @@
 import { Button, createStyles, Grid, makeStyles } from "@material-ui/core";
 import React from "react";
-import { ValidationError } from "jsonschema";
 import { QuestionnaireFormEditor } from "./QuestionnaireFormEditor";
 import { QuestionnaireJsonEditor } from "./QuestionnaireJsonEditor";
 import questionnaireSchema from "../../schemas/questionnaire.json";
@@ -9,7 +8,6 @@ import { questionnaireJsonSelector } from "../../store/questionnaireInEditor";
 
 type QuestionnaireEditorProps = {
   resetQuestionnaire: () => void;
-  schemaValidationErrors: ValidationError[];
   isJsonMode: boolean;
 };
 

--- a/react-with-json-logic/src/components/questionnaireEditor/QuestionnaireJsonEditor.tsx
+++ b/react-with-json-logic/src/components/questionnaireEditor/QuestionnaireJsonEditor.tsx
@@ -11,7 +11,7 @@ import jsonschema from "jsonschema";
 import Ajv from "ajv";
 import { useAppDispatch } from "../../store/store";
 import { useSelector } from "react-redux";
-import { questionnaireJsonSelector, setQuestionnaireInEditor } from "../../store/questionnaireInEditor";
+import { questionnaireJsonSelector, setQuestionnaireInEditor, setInvalid } from "../../store/questionnaireInEditor";
 
 type QuestionnaireFormEditorProps = {
   heightWithoutEditor: number;
@@ -64,8 +64,11 @@ export const QuestionnaireJsonEditor: React.FC<QuestionnaireFormEditorProps> = (
         schema={schema}
         onFocus={() => setHasFocus(true)}
         onBlur={() => setHasFocus(false)}
-        onChange={(newQuestionnaire: Questionnaire) => {
-          dispatch(setQuestionnaireInEditor(newQuestionnaire));
+        onChange={(newQuestionnaire: Questionnaire) => dispatch(setQuestionnaireInEditor(newQuestionnaire))}
+        onValidationError={(errors: []) => {
+          if (errors.length > 0) {
+            dispatch(setInvalid());
+          }
         }}
       />
     </div>

--- a/react-with-json-logic/src/store/questionnaireInEditor.ts
+++ b/react-with-json-logic/src/store/questionnaireInEditor.ts
@@ -14,6 +14,7 @@ import { VariableInStringRepresentation } from "../components/questionnaireEdito
 type ArraySection = SectionType.QUESTIONS | SectionType.RESULT_CATEGORIES | SectionType.VARIABLES;
 
 export const setQuestionnaireInEditor = createAction<Questionnaire>("setQuestionnaireInEditor");
+export const setInvalid = createAction("setJsonInvalid");
 export const addNewQuestion = createAction("addNewQuestion");
 export const addNewResultCategory = createAction("addNewResultCategory");
 export const addNewVariable = createAction("addNewVariable");
@@ -76,6 +77,9 @@ export const questionnaireInEditor = createReducer(initialQuestionnaireInEditor,
         questionnaire: result,
         hasErrors: false,
       };
+    })
+    .addCase(setInvalid, (state) => {
+      state.hasErrors = true;
     })
     .addCase(addNewQuestion, (state) => {
       state.questionnaire.questions.push({

--- a/react-with-json-logic/src/test/testUtils/QuestionnaireTest.tsx
+++ b/react-with-json-logic/src/test/testUtils/QuestionnaireTest.tsx
@@ -10,7 +10,7 @@ export class QuestionnaireTest {
   private readonly renderedApp: RenderResult;
 
   constructor(questionnaire: Questionnaire) {
-    this.renderedApp = render(<QuestionnaireExecution currentQuestionnaire={questionnaire} />);
+    this.renderedApp = render(<QuestionnaireExecution currentQuestionnaire={questionnaire} isJsonInvalid={false} />);
 
     this.findByText = (text: string | RegExp, selector: string | undefined) =>
       this.renderedApp.findByText(text, selector !== undefined ? { selector } : undefined);


### PR DESCRIPTION
Invalid Json Hint above Questionnaire Execution only appears, if JSON is valid, but not according to schema. Also show it if JSON is invalid.

I removed the validation by `jsonschema` library. Therefore each editor (form, JSON editor) has its own validation by its own features. Before, validation was a combination of own and common functions. If the two validations lead to different results in any case, we should have a closer look. But as both base on JSON schema, this should actually never happen.

If the editor is in JSON Mode: Should we block changing back to form mode?
If the user added invalid properties or even the JSON is completely invalid, this would not be visible in the forms, but JSON is still invalid.