### PR TITLE
fix: make timestamp conversion more stable in case no timestamp is given

### DIFF
--- a/covquestions-js/src/questionnaireEngine.test.ts
+++ b/covquestions-js/src/questionnaireEngine.test.ts
@@ -314,6 +314,25 @@ describe("questionnaireEngine", () => {
 
       expect(result["converted_date"]).toEqual("2021.04.01");
     });
+
+    it("should return emtpy timestamp from timestamp conversion if date is missing", () => {
+      const testQuestionnaire: Questionnaire = {
+        ...emptyTestQuestionnaire,
+        variables: [
+          {
+            id: "converted_date",
+            expression: {
+              convert_to_date_string: [undefined, "YYYY.MM.DD"],
+            },
+          },
+        ],
+      } as any;
+
+      const engine = new QuestionnaireEngine(testQuestionnaire);
+      const result = engine.getVariables();
+
+      expect(result["converted_date"]).toEqual("");
+    });
   });
 
   describe("round numbers", () => {

--- a/covquestions-js/src/questionnaireEngine.ts
+++ b/covquestions-js/src/questionnaireEngine.ts
@@ -361,9 +361,12 @@ export class QuestionnaireEngine {
 
   private setAdditionalJsonLogicOperators() {
     function convertToDateString(
-      timestamp: LogicExpression,
-      dateFormat: LogicExpression
-    ) {
+      timestamp?: LogicExpression,
+      dateFormat?: LogicExpression
+    ): string {
+      if (!timestamp || !dateFormat) {
+        return "";
+      }
       const timestampInMilliseconds = parseInt(timestamp.toString()) * 1000;
       return dayjs(timestampInMilliseconds).format(dateFormat.toString());
     }


### PR DESCRIPTION
Since contact dates are only set if a contact did happen, timestamps are not always available. Nonetheless, the evaluation for QR code values is called on all fields => the function has to be able to cope with missing timestamps.